### PR TITLE
Add bin to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "convert gtfs data into geojson files",
   "main": "index.js",
+  "bin": "bin/gtfs2geojson",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Adds the [bin](https://docs.npmjs.com/files/package.json#bin) key to `package.json`. This tells NPM to put the script in the proper place when `npm install`ing.
