### PR TITLE
fix typo that left shape_id NULL in lines.geojson

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ var gtfs2geojson = {
                                 type: 'Feature',
                                 id: id,
                                 properties: {
-                                    shape_id: shape_id
+                                    shape_id: id
                                 },
                                 geometry: {
                                     type: 'LineString',


### PR DESCRIPTION
Tiny change, does what it says on the tin.
